### PR TITLE
fix types declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "rollup-plugin-node-resolve": "^4.0.0",
     "typescript": "^4.6.2"
   },
-  "types": "./dist/Interval.d.ts",
+  "types": "./dist/index.d.ts",
   "browser": "./dist/index.umd.js",
   "directories": {
     "lib": "lib",


### PR DESCRIPTION
With this change, the typing for `setTemporalPolyfill` will be exported.
```js
import Interval, { setTemporalPolyfill } from 'temporal-interval'
```